### PR TITLE
fix: run watering recovery only after HA is ready

### DIFF
--- a/addon/backend/main.py
+++ b/addon/backend/main.py
@@ -47,10 +47,12 @@ async def lifespan(app: FastAPI):
     init_db()
 
     logger.info("Connecting to Home Assistant...")
+    ha_ready = False
     if settings.ha_token:
         try:
             await ha_client.connect()
             await ha_client.get_states()
+            ha_ready = True
         except Exception as e:
             logger.warning(f"HA connection failed: {e} — running in offline mode")
     else:
@@ -58,11 +60,14 @@ async def lifespan(app: FastAPI):
 
     irrigation.set_ws_broadcast(broadcast)
 
-    try:
-        recovery = await irrigation.recover_active_watering()
-        logger.info(f"Runtime recovery: {recovery}")
-    except Exception as e:
-        logger.warning(f"Runtime recovery failed: {e}")
+    if ha_ready:
+        try:
+            recovery = await irrigation.recover_active_watering()
+            logger.info(f"Runtime recovery: {recovery}")
+        except Exception as e:
+            logger.warning(f"Runtime recovery failed: {e}")
+    else:
+        logger.warning("Skipping runtime recovery — HA not ready")
 
     logger.info("Starting scheduler...")
     sched.start()


### PR DESCRIPTION
## Summary\n- run runtime recovery only when initial HA connection succeeded\n- skip recovery in offline startup mode to avoid accidental cleanup of persisted active watering state\n\nFollow-up safety fix after #17.