### PR TITLE
feat: v1.4.0 — multi-zone schedules, sensor skip fix, local time history, zone UX

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ build/
 venv/
 env/
 *.egg
+SKILL.md
 
 # Database & data
 *.db

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Irrigation BSS
+﻿# Irrigation BSS
 
 Advanced irrigation management addon for Home Assistant.
 

--- a/addon/CHANGELOG.md
+++ b/addon/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 1.4.0
+
+- Fixed: history timestamps are now displayed in local time (were incorrectly shown as UTC).
+- Fixed: entity picker in edit mode now shows the currently saved entity (valve / sensor).
+- Improved: section cards now display the list of assigned valves with a hint when none are assigned.
+- Improved: sensor skip logic now correctly uses per-schedule flags (skip_if_rain / skip_if_soil_wet / skip_if_frost).
+- Improved: flow meter and weather entity sensors now participate in watering skip evaluation.
+- Improved: sensor form now shows a description and threshold hint for each sensor type.
+- New: multi-zone sequential schedules — select multiple sections in one schedule entry and they will run one after another automatically.
+
 ## 1.3.4
 
 - Added CI validation workflow for frontend build on pull requests (develop and master).

--- a/addon/backend/models/__init__.py
+++ b/addon/backend/models/__init__.py
@@ -1,7 +1,7 @@
 from .zone import Zone, ZoneCreate, ZoneUpdate, ZoneRead
 from .valve import Valve, ValveCreate, ValveUpdate, ValveRead
 from .sensor import Sensor, SensorCreate, SensorUpdate, SensorRead, SensorType
-from .schedule import Schedule, ScheduleCreate, ScheduleUpdate, ScheduleRead, WateringMode
+from .schedule import Schedule, ScheduleCreate, ScheduleUpdate, ScheduleRead, WateringMode, schedule_zone_ids
 from .history import WateringLog, WateringLogRead, SkipReason, TriggerSource
 from .settings import AppSetting, SettingWrite
 from .runtime import ActiveWateringState
@@ -10,7 +10,7 @@ __all__ = [
     "Zone", "ZoneCreate", "ZoneUpdate", "ZoneRead",
     "Valve", "ValveCreate", "ValveUpdate", "ValveRead",
     "Sensor", "SensorCreate", "SensorUpdate", "SensorRead", "SensorType",
-    "Schedule", "ScheduleCreate", "ScheduleUpdate", "ScheduleRead", "WateringMode",
+    "Schedule", "ScheduleCreate", "ScheduleUpdate", "ScheduleRead", "WateringMode", "schedule_zone_ids",
     "WateringLog", "WateringLogRead", "SkipReason", "TriggerSource",
     "AppSetting", "SettingWrite",
     "ActiveWateringState",

--- a/addon/backend/models/history.py
+++ b/addon/backend/models/history.py
@@ -2,6 +2,7 @@ from typing import Optional
 from enum import Enum
 from datetime import datetime
 from sqlmodel import SQLModel, Field
+from pydantic import field_serializer
 
 
 class SkipReason(str, Enum):
@@ -32,6 +33,15 @@ class WateringLog(SQLModel, table=True):
     water_liters: Optional[float] = None    # from flow sensor if available
 
 
+def _to_utc_str(v: Optional[datetime]) -> Optional[str]:
+    """Serialize a naive-UTC or aware datetime to an ISO string with 'Z' suffix."""
+    if v is None:
+        return None
+    if v.tzinfo is not None:
+        return v.isoformat()
+    return v.isoformat() + "Z"
+
+
 class WateringLogRead(SQLModel):
     id: int
     zone_id: Optional[int]
@@ -43,3 +53,11 @@ class WateringLogRead(SQLModel):
     skipped: bool
     skip_reason: Optional[SkipReason]
     water_liters: Optional[float]
+
+    @field_serializer("started_at")
+    def _ser_started(self, v: datetime) -> str:
+        return _to_utc_str(v) or ""
+
+    @field_serializer("ended_at")
+    def _ser_ended(self, v: Optional[datetime]) -> Optional[str]:
+        return _to_utc_str(v)

--- a/addon/backend/models/schedule.py
+++ b/addon/backend/models/schedule.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import List, Optional
 from enum import Enum
 from sqlmodel import SQLModel, Field
 
@@ -10,6 +10,9 @@ class WateringMode(str, Enum):
 
 class ScheduleBase(SQLModel):
     zone_id: int = Field(foreign_key="zones.id")
+    # Optional comma-separated list of additional zone IDs for sequential multi-zone runs.
+    # When set, zone_id is the first zone and extra_zone_ids holds the rest.
+    extra_zone_ids: Optional[str] = Field(default=None, max_length=256)
     weekdays: int = Field(default=0b1111111, ge=0, le=127)
     start_time: str = Field(max_length=5)     # "HH:MM"
     duration_override_min: Optional[int] = Field(default=None, ge=1, le=240)
@@ -25,12 +28,24 @@ class Schedule(ScheduleBase, table=True):
     id: Optional[int] = Field(default=None, primary_key=True)
 
 
+def schedule_zone_ids(schedule: "Schedule") -> List[int]:
+    """Return all zone IDs for this schedule (primary + extras), in order."""
+    ids = [schedule.zone_id]
+    if schedule.extra_zone_ids:
+        for part in schedule.extra_zone_ids.split(","):
+            part = part.strip()
+            if part.isdigit():
+                ids.append(int(part))
+    return ids
+
+
 class ScheduleCreate(ScheduleBase):
     pass
 
 
 class ScheduleUpdate(SQLModel):
     zone_id: Optional[int] = None
+    extra_zone_ids: Optional[str] = Field(default=None, max_length=256)
     weekdays: Optional[int] = Field(default=None, ge=0, le=127)
     start_time: Optional[str] = Field(default=None, max_length=5)
     duration_override_min: Optional[int] = Field(default=None, ge=1, le=240)
@@ -44,4 +59,5 @@ class ScheduleUpdate(SQLModel):
 class ScheduleRead(ScheduleBase):
     id: int
     zone_name: Optional[str] = None
+    all_zone_ids: Optional[List[int]] = None   # resolved list: [zone_id] + extras
     next_run: Optional[str] = None   # ISO datetime string

--- a/addon/backend/routers/schedules.py
+++ b/addon/backend/routers/schedules.py
@@ -3,7 +3,7 @@ from fastapi import APIRouter, Depends, HTTPException
 from sqlmodel import Session, select
 
 from backend.database.db import get_session
-from backend.models import Schedule, ScheduleCreate, ScheduleUpdate, ScheduleRead, Zone
+from backend.models import Schedule, ScheduleCreate, ScheduleUpdate, ScheduleRead, Zone, schedule_zone_ids
 from backend.services import scheduler as sched_service
 
 router = APIRouter(prefix="/api/schedules", tags=["schedules"])
@@ -13,6 +13,7 @@ def _enrich(schedule: Schedule, session: Session) -> ScheduleRead:
     sr = ScheduleRead.model_validate(schedule)
     zone = session.get(Zone, schedule.zone_id)
     sr.zone_name = zone.name if zone else None
+    sr.all_zone_ids = schedule_zone_ids(schedule)
     sr.next_run = sched_service.get_next_run(schedule.id)
     return sr
 

--- a/addon/backend/services/irrigation.py
+++ b/addon/backend/services/irrigation.py
@@ -250,7 +250,28 @@ def get_active_zones() -> List[dict]:
     return result
 
 
-async def check_sensors_blocking(zone_id: Optional[int] = None) -> Optional[SkipReason]:
+async def check_sensors_blocking(
+    skip_if_rain: bool = True,
+    skip_if_soil_wet: bool = True,
+    skip_if_frost: bool = True,
+) -> Optional[SkipReason]:
+    """
+    Evaluate all enabled sensors and return a SkipReason if watering should be blocked.
+
+    Aggregation rule: ANY enabled sensor of the given type that exceeds its threshold
+    is sufficient to block watering (fail-safe).
+
+    Sensor types:
+    - rain:        binary (on/off). Blocks if state == 'on' and skip_if_rain is True.
+    - temperature: numeric. Blocks if value < threshold (default 2 °C) and skip_if_frost.
+    - soil:        numeric. Blocks if value > threshold (default 80 %) and skip_if_soil_wet.
+    - flow:        numeric. Blocks if value > threshold while no zone is currently active
+                   (unexpected flow may indicate a running tap or system already open).
+    - weather:     state string. Blocks on precipitation conditions (rainy/pouring/snowy/
+                   lightning-rainy) when skip_if_rain is True.
+    """
+    _RAIN_WEATHER_STATES = {"rainy", "pouring", "snowy", "snowy-rainy", "lightning-rainy", "hail"}
+
     with Session(engine) as session:
         sensors = session.exec(select(Sensor).where(Sensor.enabled == True)).all()
 
@@ -259,33 +280,62 @@ async def check_sensors_blocking(zone_id: Optional[int] = None) -> Optional[Skip
         if not state:
             continue
 
-        val = state.get("state", "")
+        val = str(state.get("state", "")).strip().lower()
+        if val in ("unknown", "unavailable", "none", ""):
+            continue
 
-        if sensor.sensor_type == SensorType.rain:
+        if sensor.sensor_type == SensorType.rain and skip_if_rain:
             if val == "on":
+                logger.info(f"Sensor block: rain sensor {sensor.entity_id} is ON")
                 return SkipReason.rain
 
-        elif sensor.sensor_type == SensorType.temperature:
+        elif sensor.sensor_type == SensorType.temperature and skip_if_frost:
             try:
                 if float(val) < (sensor.threshold if sensor.threshold is not None else 2.0):
+                    logger.info(f"Sensor block: temperature {sensor.entity_id} = {val} below threshold")
                     return SkipReason.frost
             except (ValueError, TypeError):
                 pass
 
-        elif sensor.sensor_type == SensorType.soil:
+        elif sensor.sensor_type == SensorType.soil and skip_if_soil_wet:
             try:
                 threshold = sensor.threshold if sensor.threshold is not None else 80.0
                 if float(val) > threshold:
+                    logger.info(f"Sensor block: soil moisture {sensor.entity_id} = {val}% above {threshold}%")
                     return SkipReason.soil_wet
             except (ValueError, TypeError):
                 pass
+
+        elif sensor.sensor_type == SensorType.flow:
+            # Block only when no zone is currently active — unexpected flow suggests
+            # a valve is already open or there is water usage from another source.
+            if len(_active) == 0:
+                try:
+                    threshold = sensor.threshold if sensor.threshold is not None else 0.0
+                    if float(val) > threshold:
+                        logger.info(
+                            f"Sensor block: flow meter {sensor.entity_id} = {val} L/min "
+                            f"(unexpected flow while idle, threshold={threshold})"
+                        )
+                        return SkipReason.soil_wet  # reuse closest reason; frontend shows it
+                except (ValueError, TypeError):
+                    pass
+
+        elif sensor.sensor_type == SensorType.weather and skip_if_rain:
+            raw_state = str(state.get("state", "")).strip().lower()
+            if raw_state in _RAIN_WEATHER_STATES:
+                logger.info(f"Sensor block: weather entity {sensor.entity_id} state={raw_state}")
+                return SkipReason.rain
 
     return None
 
 
 async def start_zone(zone_id: int, duration_min: Optional[int] = None,
                      triggered_by: TriggerSource = TriggerSource.manual,
-                     skip_sensor_check: bool = False) -> dict:
+                     skip_sensor_check: bool = False,
+                     skip_if_rain: bool = True,
+                     skip_if_soil_wet: bool = True,
+                     skip_if_frost: bool = True) -> dict:
     with Session(engine) as session:
         zone = session.get(Zone, zone_id)
         if not zone:
@@ -306,7 +356,11 @@ async def start_zone(zone_id: int, duration_min: Optional[int] = None,
         zone_name = zone.name
 
     if not skip_sensor_check:
-        skip = await check_sensors_blocking(zone_id)
+        skip = await check_sensors_blocking(
+            skip_if_rain=skip_if_rain,
+            skip_if_soil_wet=skip_if_soil_wet,
+            skip_if_frost=skip_if_frost,
+        )
         if skip:
             _log_skip(zone_id, zone_name, valve_ids, skip, triggered_by)
             return {"ok": False, "skipped": True, "skip_reason": skip.value}

--- a/addon/backend/services/scheduler.py
+++ b/addon/backend/services/scheduler.py
@@ -1,6 +1,7 @@
 """
 APScheduler — loads schedules from DB, fires zone watering at configured times.
 """
+import asyncio
 import logging
 from datetime import datetime
 
@@ -9,7 +10,7 @@ from apscheduler.triggers.cron import CronTrigger
 from sqlmodel import Session, select
 
 from backend.database.db import engine
-from backend.models import Schedule, Zone, TriggerSource
+from backend.models import Schedule, Zone, TriggerSource, schedule_zone_ids
 from backend.services import irrigation
 
 logger = logging.getLogger(__name__)
@@ -29,17 +30,56 @@ async def _fire_schedule(schedule_id: int):
         schedule = session.get(Schedule, schedule_id)
         if not schedule or not schedule.enabled:
             return
+        zone_ids = schedule_zone_ids(schedule)
         zone = session.get(Zone, schedule.zone_id)
         zone_name = zone.name if zone else "Unknown"
+        skip_if_rain = schedule.skip_if_rain
+        skip_if_soil_wet = schedule.skip_if_soil_wet
+        skip_if_frost = schedule.skip_if_frost
+        duration_override = schedule.duration_override_min
+        mode = schedule.mode
 
-    logger.info(f"Scheduler firing: zone_id={schedule.zone_id} ({zone_name})")
-    result = await irrigation.start_zone(
-        zone_id=schedule.zone_id,
-        duration_min=schedule.duration_override_min,
-        triggered_by=TriggerSource.schedule,
+    logger.info(
+        f"Scheduler firing: schedule_id={schedule_id} zones={zone_ids} "
+        f"mode={mode} ({zone_name} + {len(zone_ids)-1} more)"
     )
-    if not result.get("ok"):
-        logger.warning(f"Schedule {schedule_id} skipped: {result}")
+
+    if mode == "sequential" or len(zone_ids) > 1:
+        # Sequential: run each zone one after another, waiting for completion.
+        for zid in zone_ids:
+            result = await irrigation.start_zone(
+                zone_id=zid,
+                duration_min=duration_override,
+                triggered_by=TriggerSource.schedule,
+                skip_if_rain=skip_if_rain,
+                skip_if_soil_wet=skip_if_soil_wet,
+                skip_if_frost=skip_if_frost,
+            )
+            if not result.get("ok"):
+                logger.warning(f"Schedule {schedule_id} zone {zid} skipped/failed: {result}")
+                if result.get("skipped"):
+                    # Sensor block applies globally — skip remaining zones too
+                    break
+                continue
+            # Wait for the zone to finish before starting the next one
+            elapsed = 0
+            wait_interval = 5
+            total_wait = (result.get("duration_min") or 15) * 60 + 30  # +30s buffer
+            while irrigation.is_watering(zid) and elapsed < total_wait:
+                await asyncio.sleep(wait_interval)
+                elapsed += wait_interval
+    else:
+        # Parallel: just start the single (or all) zones without waiting
+        result = await irrigation.start_zone(
+            zone_id=zone_ids[0],
+            duration_min=duration_override,
+            triggered_by=TriggerSource.schedule,
+            skip_if_rain=skip_if_rain,
+            skip_if_soil_wet=skip_if_soil_wet,
+            skip_if_frost=skip_if_frost,
+        )
+        if not result.get("ok"):
+            logger.warning(f"Schedule {schedule_id} skipped: {result}")
 
 
 def reload_schedules():

--- a/addon/config.yaml
+++ b/addon/config.yaml
@@ -1,5 +1,5 @@
 name: "Irrigation BSS"
-version: "1.3.4"
+version: "1.4.0"
 slug: "irrigation_bss"
 description: "Advanced irrigation management — zones, valves, sensors, scheduler"
 url: "https://github.com/BSS-Baumgart/bss_ha_irrigation"

--- a/addon/frontend/public/locales/de/translation.json
+++ b/addon/frontend/public/locales/de/translation.json
@@ -72,7 +72,8 @@
     "startZone": "Starten",
     "stopZone": "Stoppen",
     "isWatering": "Bewässert...",
-    "noValves": "Keine Ventile"
+    "noValves": "Keine Ventile",
+    "assignValvesHint": "Keine Ventile zugewiesen — gehe zu Ventile, um sie dieser Sektion zuzuweisen."
   },
   "valves": {
     "title": "Ventile",
@@ -105,6 +106,18 @@
       "weather": "Wetter"
     },
     "threshold": "Schwellenwert",
+    "typeDescs": {
+      "rain": "Binärer Sensor (z.B. Regensensor). Blockiert bei Zustand ON.",
+      "soil": "Bodenfeuchtesensor (%). Blockiert wenn Feuchtigkeit über Schwellenwert liegt.",
+      "flow": "Durchflussmesser (L/min). Blockiert Start bei unerwartetem Durchfluss ohne aktive Sektion.",
+      "temperature": "Temperatursensor (°C). Frostschutz: blockiert Bewässerung unter dem Schwellenwert.",
+      "weather": "HA Wetterentität. Blockiert bei Niederschlag laut Wetterzustand."
+    },
+    "thresholdDescs": {
+      "soil": "Bewässerung blockieren wenn Bodenfeuchte diesen Wert überschreitet.",
+      "flow": "Start blockieren wenn Durchfluss diesen Wert überschreitet ohne aktive Sektion (0 = beliebig).",
+      "temperature": "Bewässerung bei Frost blockieren (unter diesem Temperaturwert)."
+    },
     "blocking": "Blockiert Bewässerung",
     "notBlocking": "Bewässerung erlaubt",
     "currentValue": "Aktueller Wert"
@@ -116,6 +129,8 @@
     "deleteSchedule": "Zeitplan löschen",
     "deleteConfirm": "Möchten Sie diesen Zeitplan wirklich löschen?",
     "zone": "Sektion",
+    "zones": "Sektionen",
+    "multiZoneHint": "{{count}} Sektionen werden nacheinander ausgeführt.",
     "startTime": "Startzeit",
     "duration": "Dauer (min)",
     "durationOverride": "Dauer überschreiben",

--- a/addon/frontend/public/locales/en/translation.json
+++ b/addon/frontend/public/locales/en/translation.json
@@ -72,7 +72,8 @@
     "startZone": "Start",
     "stopZone": "Stop",
     "isWatering": "Watering...",
-    "noValves": "No valves"
+    "noValves": "No valves",
+    "assignValvesHint": "No valves assigned — go to Valves to assign them to this section."
   },
   "valves": {
     "title": "Valves",
@@ -105,6 +106,18 @@
       "weather": "Weather"
     },
     "threshold": "Threshold",
+    "typeDescs": {
+      "rain": "Binary sensor (e.g. rain gauge contact). Blocks watering when state is ON.",
+      "soil": "Soil moisture sensor (%). Blocks watering when moisture exceeds the threshold.",
+      "flow": "Flow meter (L/min). Blocks watering start when unexpected flow is detected while no zone is active.",
+      "temperature": "Temperature sensor (\u00b0C). Frost protection: blocks watering when temperature is below the threshold.",
+      "weather": "HA weather entity. Blocks watering when the weather condition indicates precipitation."
+    },
+    "thresholdDescs": {
+      "soil": "Block watering when soil moisture is above this value.",
+      "flow": "Block watering when flow is above this value while no zone is active (0 = any flow).",
+      "temperature": "Block watering when temperature is below this value (frost protection)."
+    },
     "blocking": "Blocking watering",
     "notBlocking": "Watering allowed",
     "currentValue": "Current value"
@@ -116,6 +129,8 @@
     "deleteSchedule": "Delete schedule",
     "deleteConfirm": "Are you sure you want to delete this schedule?",
     "zone": "Section",
+    "zones": "Sections",
+    "multiZoneHint": "{{count}} sections will run sequentially one after another.",
     "startTime": "Start time",
     "duration": "Duration (min)",
     "durationOverride": "Override duration",

--- a/addon/frontend/public/locales/pl/translation.json
+++ b/addon/frontend/public/locales/pl/translation.json
@@ -72,7 +72,8 @@
     "startZone": "Uruchom",
     "stopZone": "Zatrzymaj",
     "isWatering": "Podlewa...",
-    "noValves": "Brak zaworów"
+    "noValves": "Brak zaworów",
+    "assignValvesHint": "Brak przypisanych zaworów — przejdź do Zaworów, aby przypisać je do tej sekcji."
   },
   "valves": {
     "title": "Zawory",
@@ -105,6 +106,18 @@
       "weather": "Pogoda"
     },
     "threshold": "Próg",
+    "typeDescs": {
+      "rain": "Czujnik binarny (np. taca deszczowa). Blokuje podlewanie gdy stan to ON.",
+      "soil": "Czujnik wilgotności gleby (%). Blokuje podlewanie gdy wilgotność przekroczy próg.",
+      "flow": "Przepływomierz (L/min). Blokuje start gdy wykryje przepływ wody przy braku aktywnej sekcji.",
+      "temperature": "Czujnik temperatury (°C). Ochrona przed mrozem: blokuje podlewanie poniżej progu.",
+      "weather": "Encja pogodowa HA. Blokuje podlewanie gdy stan pogody wskazuje opady."
+    },
+    "thresholdDescs": {
+      "soil": "Blokuj podlewanie gdy wilgotność gleby przekracza tę wartość.",
+      "flow": "Blokuj start gdy przepływ przekracza tę wartość przy braku aktywnej sekcji (0 = jakikolwiek przepływ).",
+      "temperature": "Blokuj podlewanie gdy temperatura spada poniżej tej wartości (ochrona przed mrozem)."
+    },
     "blocking": "Blokuje podlewanie",
     "notBlocking": "Podlewanie dozwolone",
     "currentValue": "Aktualna wartość"
@@ -116,6 +129,8 @@
     "deleteSchedule": "Usuń harmonogram",
     "deleteConfirm": "Czy na pewno chcesz usunąć ten harmonogram?",
     "zone": "Sekcja",
+    "zones": "Sekcje",
+    "multiZoneHint": "{{count}} sekcje będą uruchomione sekwencyjnie jedna po drugiej.",
     "startTime": "Godzina startu",
     "duration": "Czas trwania (min)",
     "durationOverride": "Nadpisz czas trwania",

--- a/addon/frontend/src/pages/HistoryPage.tsx
+++ b/addon/frontend/src/pages/HistoryPage.tsx
@@ -13,6 +13,13 @@ function formatDuration(sec?: number) {
   return `${m}m ${s}s`
 }
 
+/** Parse date string treating bare ISO strings (no tz indicator) as UTC. */
+function parseUtcDate(value: string): Date {
+  if (!value) return new Date(NaN)
+  const normalized = value.endsWith('Z') || value.includes('+') ? value : value + 'Z'
+  return new Date(normalized)
+}
+
 export default function HistoryPage() {
   const { t } = useTranslation()
   const [logs, setLogs] = useState<WateringLog[]>([])
@@ -70,7 +77,7 @@ export default function HistoryPage() {
               {logs.map(log => (
                 <tr key={log.id} className="hover:bg-gray-100 dark:hover:bg-gray-800/50 transition-colors">
                   <td className="px-4 py-3 text-gray-300 whitespace-nowrap">
-                    {new Date(log.started_at).toLocaleString()}
+                    {parseUtcDate(log.started_at).toLocaleString()}
                   </td>
                   <td className="px-4 py-3 text-gray-900 dark:text-white font-medium">{log.zone_name}</td>
                   <td className="px-4 py-3 text-gray-400 font-mono">{formatDuration(log.duration_sec)}</td>

--- a/addon/frontend/src/pages/SchedulePage.tsx
+++ b/addon/frontend/src/pages/SchedulePage.tsx
@@ -23,8 +23,15 @@ function ScheduleForm({ initial, zones, onSave, onCancel }: {
   onSave: (data: Partial<Schedule>) => Promise<void>; onCancel: () => void
 }) {
   const { t } = useTranslation()
+
+  // Resolve initial selected zone IDs (all_zone_ids from backend or just zone_id)
+  const initialZoneIds: number[] = initial?.all_zone_ids?.length
+    ? initial.all_zone_ids
+    : initial?.zone_id ? [initial.zone_id] : (zones[0] ? [zones[0].id] : [])
+
+  const [selectedZoneIds, setSelectedZoneIds] = useState<number[]>(initialZoneIds)
   const [form, setForm] = useState<Partial<Schedule>>({
-    zone_id: zones[0]?.id, weekdays: 0b1111111, start_time: '07:00',
+    zone_id: initialZoneIds[0], weekdays: 0b1111111, start_time: '07:00',
     duration_override_min: undefined, mode: 'sequential', enabled: true,
     skip_if_rain: true, skip_if_soil_wet: true, skip_if_frost: true,
     ...initial,
@@ -39,9 +46,27 @@ function ScheduleForm({ initial, zones, onSave, onCancel }: {
     setDays(nd); set('weekdays', bitmaskFromWeekdays(nd))
   }
 
+  const toggleZone = (zoneId: number) => {
+    setSelectedZoneIds(prev => {
+      if (prev.includes(zoneId)) {
+        // At least one zone must be selected
+        if (prev.length === 1) return prev
+        return prev.filter(id => id !== zoneId)
+      } else {
+        return [...prev, zoneId]
+      }
+    })
+  }
+
   const submit = async (e: React.FormEvent) => {
     e.preventDefault(); setSaving(true); setErr('')
-    try { await onSave(form) }
+    const [primaryZone, ...extras] = selectedZoneIds
+    const payload: Partial<Schedule> = {
+      ...form,
+      zone_id: primaryZone,
+      extra_zone_ids: extras.length > 0 ? extras.join(',') : undefined,
+    }
+    try { await onSave(payload) }
     catch (e: unknown) { setErr(e instanceof Error ? e.message : String(e)) }
     finally { setSaving(false) }
   }
@@ -50,12 +75,24 @@ function ScheduleForm({ initial, zones, onSave, onCancel }: {
     <form onSubmit={submit} className="p-5 space-y-4">
       {err && <div className="bg-red-900/40 border border-red-800 text-red-300 text-sm rounded-lg px-3 py-2">{err}</div>}
       <div>
-        <label className="label">{t('schedule.zone')} *</label>
-        <select className="input" required value={form.zone_id ?? ''}
-          onChange={e => set('zone_id', Number(e.target.value))}>
-          <option value="">— {t('schedule.zone')} —</option>
-          {zones.map(z => <option key={z.id} value={z.id}>{z.name}</option>)}
-        </select>
+        <label className="label">{t('schedule.zones')} *</label>
+        <div className="border border-gray-200 dark:border-gray-700 rounded-lg overflow-hidden max-h-44 overflow-y-auto">
+          {zones.map(z => (
+            <button key={z.id} type="button" onClick={() => toggleZone(z.id)}
+              className={`w-full text-left px-3 py-2 flex items-center gap-2 text-sm hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors ${selectedZoneIds.includes(z.id) ? 'bg-primary-900/30 text-primary-300' : 'text-gray-300'}`}>
+              <div className="w-2.5 h-2.5 rounded-full shrink-0" style={{ backgroundColor: z.color }} />
+              {z.name}
+              {selectedZoneIds.includes(z.id) && (
+                <span className="ml-auto text-xs bg-primary-800 text-primary-300 px-1.5 py-0.5 rounded">
+                  #{selectedZoneIds.indexOf(z.id) + 1}
+                </span>
+              )}
+            </button>
+          ))}
+        </div>
+        {selectedZoneIds.length > 1 && (
+          <p className="text-xs text-primary-400 mt-1">{t('schedule.multiZoneHint', { count: selectedZoneIds.length })}</p>
+        )}
       </div>
       <div className="grid grid-cols-2 gap-3">
         <div>
@@ -158,9 +195,22 @@ export default function SchedulePage() {
           {schedules.map(sch => (
             <div key={sch.id} className="card hover:border-gray-700 transition-colors">
               <div className="flex items-start justify-between mb-3">
-                <div>
+                <div className="min-w-0 flex-1">
                   <div className="font-semibold text-gray-900 dark:text-white text-lg">{sch.start_time}</div>
-                  <div className="text-sm text-gray-400 mt-0.5">{sch.zone_name}</div>
+                  {sch.all_zone_ids && sch.all_zone_ids.length > 1 ? (
+                    <div className="flex flex-wrap gap-1 mt-1">
+                      {sch.all_zone_ids.map((zid, idx) => {
+                        const z = zones.find(x => x.id === zid)
+                        return z ? (
+                          <span key={zid} className="inline-flex items-center gap-1 text-xs bg-gray-800 text-gray-300 px-1.5 py-0.5 rounded">
+                            <span className="text-gray-500">{idx + 1}.</span> {z.name}
+                          </span>
+                        ) : null
+                      })}
+                    </div>
+                  ) : (
+                    <div className="text-sm text-gray-400 mt-0.5">{sch.zone_name}</div>
+                  )}
                 </div>
                 <div className="flex gap-1 shrink-0">
                   <button onClick={() => { setSelected(sch); setModal('edit') }}

--- a/addon/frontend/src/pages/SensorsPage.tsx
+++ b/addon/frontend/src/pages/SensorsPage.tsx
@@ -74,8 +74,11 @@ function SensorForm({ initial, onSave, onCancel }: {
     finally { setSaving(false) }
   }
 
-  const showThreshold = form.sensor_type === 'soil' || form.sensor_type === 'temperature'
-  const thresholdLabel = form.sensor_type === 'soil' ? `${t('sensors.threshold')} (%)` : `${t('sensors.threshold')} (°C)`
+  const showThreshold = form.sensor_type === 'soil' || form.sensor_type === 'temperature' || form.sensor_type === 'flow'
+  const thresholdLabel =
+    form.sensor_type === 'soil' ? `${t('sensors.threshold')} (%)` :
+    form.sensor_type === 'flow' ? `${t('sensors.threshold')} (L/min)` :
+    `${t('sensors.threshold')} (°C)`
 
   return (
     <form onSubmit={submit} className="p-5 space-y-4">
@@ -86,6 +89,7 @@ function SensorForm({ initial, onSave, onCancel }: {
           onChange={e => set('sensor_type', e.target.value as SensorType)}>
           {SENSOR_TYPES.map(tp => <option key={tp} value={tp}>{t(`sensors.types.${tp}`)}</option>)}
         </select>
+        <p className="text-xs text-gray-500 mt-1">{t(`sensors.typeDescs.${form.sensor_type}`)}</p>
       </div>
       <div>
         <label className="label">{t('valves.entityId')} *</label>
@@ -100,10 +104,10 @@ function SensorForm({ initial, onSave, onCancel }: {
         <div>
           <label className="label">{thresholdLabel}</label>
           <input className="input" type="number" step="0.1"
-            value={form.threshold ?? (form.sensor_type === 'soil' ? 80 : 2)}
+            value={form.threshold ?? (form.sensor_type === 'soil' ? 80 : form.sensor_type === 'flow' ? 0 : 2)}
             onChange={e => set('threshold', Number(e.target.value))} />
           <p className="text-xs text-gray-500 mt-1">
-            {form.sensor_type === 'soil' ? 'Skip watering when soil moisture exceeds this value' : 'Freeze protection: block watering below this temperature'}
+            {t(`sensors.thresholdDescs.${form.sensor_type}`)}
           </p>
         </div>
       )}

--- a/addon/frontend/src/pages/ZonesPage.tsx
+++ b/addon/frontend/src/pages/ZonesPage.tsx
@@ -1,9 +1,10 @@
 import { useState, useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
-import { Plus, Play, Square, Pencil, Trash2, Layers } from 'lucide-react'
+import { Plus, Play, Square, Pencil, Trash2, Layers, Zap } from 'lucide-react'
 import { zonesApi } from '../api/zones'
+import { valvesApi } from '../api/valves'
 import { irrigationApi } from '../api/irrigation'
-import type { Zone } from '../types'
+import type { Zone, Valve } from '../types'
 import Modal from '../components/common/Modal'
 import ConfirmDialog from '../components/common/ConfirmDialog'
 import StatusBadge from '../components/common/StatusBadge'
@@ -109,12 +110,16 @@ function StartDialog({ zone, onClose }: { zone: Zone; onClose: () => void }) {
 export default function ZonesPage() {
   const { t } = useTranslation()
   const [zones, setZones] = useState<Zone[]>([])
+  const [valves, setValves] = useState<Valve[]>([])
   const [loading, setLoading] = useState(true)
   const [modal, setModal] = useState<'add' | 'edit' | 'start' | null>(null)
   const [selected, setSelected] = useState<Zone | null>(null)
   const [deleteTarget, setDeleteTarget] = useState<Zone | null>(null)
 
-  const load = () => zonesApi.list().then(setZones).finally(() => setLoading(false))
+  const load = () => Promise.all([
+    zonesApi.list().then(setZones),
+    valvesApi.list().then(setValves),
+  ]).finally(() => setLoading(false))
   useEffect(() => { load() }, [])
 
   useEffect(() => {
@@ -154,7 +159,9 @@ export default function ZonesPage() {
         </div>
       ) : (
         <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4">
-          {zones.map(zone => (
+          {zones.map(zone => {
+            const zoneValves = valves.filter(v => v.zone_id === zone.id)
+            return (
             <div key={zone.id} className="card hover:border-gray-700 transition-colors">
               <div className="flex items-start justify-between mb-3">
                 <div className="flex items-center gap-2 min-w-0">
@@ -169,12 +176,28 @@ export default function ZonesPage() {
                 </div>
               </div>
               {zone.description && <p className="text-xs text-gray-500 mb-3 truncate">{zone.description}</p>}
-              <div className="flex flex-wrap gap-2 text-xs text-gray-500 dark:text-gray-400 mb-4">
+              <div className="flex flex-wrap gap-2 text-xs text-gray-500 dark:text-gray-400 mb-3">
                 <span className="bg-gray-100 dark:bg-gray-800 px-2 py-0.5 rounded">{zone.duration_min} min</span>
                 <span className="bg-gray-100 dark:bg-gray-800 px-2 py-0.5 rounded">#{zone.sequence_order}</span>
-                <span className="bg-gray-100 dark:bg-gray-800 px-2 py-0.5 rounded">{zone.valve_count} {t('zones.valveCount').toLowerCase()}</span>
                 {!zone.enabled && <StatusBadge variant="gray">{t('common.disabled')}</StatusBadge>}
               </div>
+
+              {/* Valve list */}
+              <div className="mb-4 min-h-[28px]">
+                {zoneValves.length === 0 ? (
+                  <p className="text-xs text-yellow-600 dark:text-yellow-500 italic">{t('zones.assignValvesHint')}</p>
+                ) : (
+                  <div className="flex flex-wrap gap-1.5">
+                    {zoneValves.map(v => (
+                      <span key={v.id}
+                        className="inline-flex items-center gap-1 text-xs bg-gray-100 dark:bg-gray-800 text-gray-600 dark:text-gray-300 px-2 py-0.5 rounded">
+                        <Zap size={10} className="opacity-50" />{v.name}
+                      </span>
+                    ))}
+                  </div>
+                )}
+              </div>
+
               <div className="flex items-center justify-between">
                 {zone.is_watering
                   ? <StatusBadge variant="green" pulse>{t('zones.isWatering')}</StatusBadge>
@@ -186,17 +209,14 @@ export default function ZonesPage() {
                   </button>
                 ) : (
                   <button onClick={() => { setSelected(zone); setModal('start') }}
-                    disabled={!zone.enabled || zone.valve_count === 0}
+                    disabled={!zone.enabled || zoneValves.length === 0}
                     className="btn-primary btn-sm flex items-center gap-1.5 disabled:opacity-40">
                     <Play size={11} />{t('zones.startZone')}
                   </button>
                 )}
               </div>
-              {zone.valve_count === 0 && !zone.is_watering && (
-                <p className="text-xs text-yellow-600 mt-2">{t('zones.noValves')}</p>
-              )}
             </div>
-          ))}
+          )})}
         </div>
       )}
 

--- a/addon/frontend/src/types/index.ts
+++ b/addon/frontend/src/types/index.ts
@@ -40,6 +40,8 @@ export type WateringMode = 'sequential' | 'parallel'
 export interface Schedule {
   id: number
   zone_id: number
+  extra_zone_ids?: string    // comma-separated extra zone IDs
+  all_zone_ids?: number[]    // resolved list from backend
   zone_name?: string
   weekdays: number   // bitmask
   start_time: string // "HH:MM"


### PR DESCRIPTION
## Summary

Fixes all open issues from the backlog:

### Bug fixes
- **#21**: History timestamps now displayed in local time (backend returns UTC 'Z' suffix; frontend interprets correctly)
- **#13**: EntityPicker prefill in edit mode was already fixed in v1.3.4 remote branch

### UX improvements
- **#12**: Section cards now show assigned valve names; hint displayed when no valves are assigned
- **#14**: Sensor skip logic now respects per-schedule flags (\skip_if_rain\, \skip_if_soil_wet\, \skip_if_frost\); flow meter and weather entity sensors now participate in skip evaluation; sensor form shows type descriptions and threshold hints

### New features
- **#20**: Multi-zone sequential schedules — select multiple sections in one schedule entry; scheduler runs them one after another automatically

### Other
- Version bumped to 1.4.0
- CHANGELOG updated

Closes #12 #13 #14 #20 #21