### PR TITLE
chore(frontend): remove deprecated baseUrl from tsconfig

### DIFF
--- a/addon/frontend/tsconfig.json
+++ b/addon/frontend/tsconfig.json
@@ -15,9 +15,8 @@
     "noUnusedLocals": false,
     "noUnusedParameters": false,
     "noFallthroughCasesInSwitch": true,
-    "baseUrl": ".",
     "paths": {
-      "@/*": ["src/*"]
+      "@/*": ["./src/*"]
     }
   },
   "include": ["src"],


### PR DESCRIPTION
Removes deprecated \aseUrl\ option from tsconfig.json (deprecated in TS 6.0, will stop working in TS 7.0). Updates paths alias to use relative \./src/*\ instead.