### PR TITLE
release: v1.4.1

### DIFF
--- a/addon/CHANGELOG.md
+++ b/addon/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.4.1
+
+- Fixed: startup crash on existing installations after upgrade to v1.4.0 — missing `extra_zone_ids` column in the SQLite database is now added automatically via a migration on startup.
+- Fixed: removed deprecated `baseUrl` from frontend TypeScript configuration.
+
 ## 1.4.0
 
 - Fixed: history timestamps are now displayed in local time (were incorrectly shown as UTC).

--- a/addon/backend/database/db.py
+++ b/addon/backend/database/db.py
@@ -1,11 +1,36 @@
+import logging
 from sqlmodel import SQLModel, create_engine, Session
 from backend.config import settings
 
+logger = logging.getLogger(__name__)
+
 engine = create_engine(settings.db_path, echo=False)
+
+# Each entry: (table, column, column_definition)
+_MIGRATIONS: list[tuple[str, str, str]] = [
+    ("schedules", "extra_zone_ids", "TEXT"),
+]
+
+
+def _run_migrations() -> None:
+    """Apply incremental ALTER TABLE migrations for columns added after initial release."""
+    with engine.connect() as conn:
+        for table, column, col_def in _MIGRATIONS:
+            rows = conn.exec_driver_sql(
+                f"PRAGMA table_info({table})"  # noqa: S608
+            ).fetchall()
+            existing = {row[1] for row in rows}
+            if column not in existing:
+                logger.info("Migration: adding column %s.%s", table, column)
+                conn.exec_driver_sql(
+                    f"ALTER TABLE {table} ADD COLUMN {column} {col_def}"  # noqa: S608
+                )
+                conn.commit()
 
 
 def init_db():
     SQLModel.metadata.create_all(engine)
+    _run_migrations()
 
 
 def get_session():

--- a/addon/config.yaml
+++ b/addon/config.yaml
@@ -1,5 +1,5 @@
 name: "Irrigation BSS"
-version: "1.4.0"
+version: "1.4.1"
 slug: "irrigation_bss"
 description: "Advanced irrigation management — zones, valves, sensors, scheduler"
 url: "https://github.com/BSS-Baumgart/bss_ha_irrigation"

--- a/addon/frontend/tsconfig.json
+++ b/addon/frontend/tsconfig.json
@@ -15,9 +15,8 @@
     "noUnusedLocals": false,
     "noUnusedParameters": false,
     "noFallthroughCasesInSwitch": true,
-    "baseUrl": ".",
     "paths": {
-      "@/*": ["src/*"]
+      "@/*": ["./src/*"]
     }
   },
   "include": ["src"],


### PR DESCRIPTION
Patch release v1.4.1.

- fix(db): migrate extra_zone_ids column on existing databases (fixes startup crash after v1.4.0 upgrade)
- chore(frontend): remove deprecated baseUrl from tsconfig