### PR TITLE
feat: pump control, color theme, force start, flow sensor fix (v1.4.3)

### DIFF
--- a/addon/CHANGELOG.md
+++ b/addon/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 1.4.3
+
+- Fixed: Flow meter sensor now correctly reports "Unexpected flow" (instead of "Wet soil") in irrigation history.
+- Fixed: Safety sweep — all zone valves are explicitly closed when the last active zone finishes (prevents stuck-open valves).
+- Fixed: Manual start now supports a "Force start" option to bypass active sensor blocks (soil, rain, frost, flow).
+- New: Pump control — configure a pump entity (e.g. well pump) that starts automatically with the first section and stops after the last, mirroring main valve behaviour.
+- New: Settings page — language selector (EN/PL/DE) and 6 customisable interface colours (hex input + colour picker), all persisted to the database.
+
 ## 1.4.2
 
 - Fixed: HA WebSocket "Cannot write to closing transport" error after Home Assistant restart — sends are now guarded by a connection-state flag that is only set after successful `auth_ok`.

--- a/addon/backend/main.py
+++ b/addon/backend/main.py
@@ -138,7 +138,19 @@ def health():
 
 @app.get("/api/config")
 def get_config():
-    return {"language": settings.default_language}
+    # DB language override takes precedence over addon env var
+    lang = settings.default_language
+    try:
+        from sqlmodel import Session, select
+        from backend.models import AppSetting
+        from backend.database.db import engine
+        with Session(engine) as session:
+            row = session.get(AppSetting, "app_language")
+            if row and row.value:
+                lang = row.value
+    except Exception:
+        pass
+    return {"language": lang}
 
 
 static_dir = settings.static_dir

--- a/addon/backend/models/history.py
+++ b/addon/backend/models/history.py
@@ -9,6 +9,7 @@ class SkipReason(str, Enum):
     rain = "rain"
     soil_wet = "soil_wet"
     frost = "frost"
+    flow_detected = "flow_detected"
     manual_stop = "manual_stop"
     ha_unavailable = "ha_unavailable"
 

--- a/addon/backend/routers/irrigation.py
+++ b/addon/backend/routers/irrigation.py
@@ -10,6 +10,7 @@ router = APIRouter(prefix="/api/irrigation", tags=["irrigation"])
 
 class StartRequest(BaseModel):
     duration_min: Optional[int] = None
+    force: bool = False   # bypass sensor checks when True
 
 
 @router.get("/status")
@@ -27,6 +28,7 @@ async def start_zone(zone_id: int, body: StartRequest = StartRequest()):
         zone_id=zone_id,
         duration_min=body.duration_min,
         triggered_by=TriggerSource.manual,
+        skip_sensor_check=body.force,
     )
     if not result.get("ok") and not result.get("skipped"):
         raise HTTPException(400, result.get("error", "Cannot start zone"))

--- a/addon/backend/services/irrigation.py
+++ b/addon/backend/services/irrigation.py
@@ -64,6 +64,16 @@ def _get_main_valve_entity() -> Optional[str]:
         return None
 
 
+def _get_pump_entity() -> Optional[str]:
+    try:
+        with Session(engine) as session:
+            row = session.get(AppSetting, "pump_entity_id")
+            return row.value if row and row.value else None
+    except Exception as e:
+        logger.warning(f"Cannot read pump setting: {e}")
+        return None
+
+
 def _persist_active_state(zone_id: int, zone_name: str, valve_entities: List[str],
                           started_at: datetime, duration_min: int, log_id: Optional[int]) -> None:
     planned_end_at = started_at + timedelta(minutes=duration_min)
@@ -186,6 +196,15 @@ async def recover_active_watering() -> dict:
                         logger.info(f"Main valve {main_valve} reopened during recovery")
                 except Exception as e:
                     logger.warning(f"Main valve reopen failed ({main_valve}): {e}")
+
+            pump_valve = _get_pump_entity()
+            if pump_valve:
+                try:
+                    if not await _is_entity_on(pump_valve):
+                        await ha_client.turn_on(pump_valve)
+                        logger.info(f"Pump {pump_valve} restarted during recovery")
+                except Exception as e:
+                    logger.warning(f"Pump restart failed ({pump_valve}): {e}")
 
         for idx, entity_id in enumerate(valve_entities):
             if on_states[idx]:
@@ -317,7 +336,7 @@ async def check_sensors_blocking(
                             f"Sensor block: flow meter {sensor.entity_id} = {val} L/min "
                             f"(unexpected flow while idle, threshold={threshold})"
                         )
-                        return SkipReason.soil_wet  # reuse closest reason; frontend shows it
+                        return SkipReason.flow_detected
                 except (ValueError, TypeError):
                     pass
 
@@ -376,6 +395,14 @@ async def start_zone(zone_id: int, duration_min: Optional[int] = None,
                 logger.info(f"Main valve {main_valve} opened")
             except Exception as e:
                 logger.warning(f"Main valve open failed ({main_valve}): {e}")
+
+        pump_valve = _get_pump_entity()
+        if pump_valve:
+            try:
+                await ha_client.turn_on(pump_valve)
+                logger.info(f"Pump {pump_valve} started")
+            except Exception as e:
+                logger.warning(f"Pump start failed ({pump_valve}): {e}")
 
     for entity_id in valve_entities:
         try:
@@ -480,6 +507,27 @@ async def _finish_zone(zone_id: int, info: dict, reason: str,
                 logger.info(f"Main valve {main_valve} closed")
             except Exception as e:
                 logger.warning(f"Main valve close failed ({main_valve}): {e}")
+
+        pump_valve = _get_pump_entity()
+        if pump_valve:
+            try:
+                await ha_client.turn_off(pump_valve)
+                logger.info(f"Pump {pump_valve} closed")
+            except Exception as e:
+                logger.warning(f"Pump close failed ({pump_valve}): {e}")
+
+        # Safety sweep: close all zone valves in DB to guard against any stuck valve
+        try:
+            with Session(engine) as session:
+                all_valves = session.exec(select(Valve).where(Valve.enabled == True)).all()
+            for v in all_valves:
+                try:
+                    await ha_client.turn_off(v.entity_id)
+                except Exception:
+                    pass
+            logger.info("Safety sweep: all zone valves closed")
+        except Exception as e:
+            logger.warning(f"Safety sweep failed: {e}")
 
     _update_log(info.get("log_id"), info.get("started_at"), skipped=skipped, skip_reason=skip_reason)
     await _broadcast("zone_stopped", {"zone_id": zone_id, "reason": reason, "active_zones": get_active_zones()})

--- a/addon/config.yaml
+++ b/addon/config.yaml
@@ -1,5 +1,5 @@
 name: "Irrigation BSS"
-version: "1.4.2"
+version: "1.4.3"
 slug: "irrigation_bss"
 description: "Advanced irrigation management — zones, valves, sensors, scheduler"
 url: "https://github.com/BSS-Baumgart/bss_ha_irrigation"

--- a/addon/frontend/public/locales/de/translation.json
+++ b/addon/frontend/public/locales/de/translation.json
@@ -56,6 +56,7 @@
     "manualStart": "Manueller Start",
     "quickStart": "Schnellstart",
     "wateringBlocked": "Bewässerung durch Sensoren blockiert:",
+    "forceStart": "Erzwungener Start (Sensorblockaden ignorieren)",
     "remaining": "verbleibend",
     "noZones": "Keine Sektionen konfiguriert."
   },
@@ -89,7 +90,9 @@
     "turnOn": "Einschalten",
     "turnOff": "Ausschalten",
     "mainValve": "Hauptventil",
-    "mainValveDesc": "Öffnet automatisch vor der ersten Sektion und schließt nach der letzten."
+    "mainValveDesc": "Öffnet automatisch vor der ersten Sektion und schließt nach der letzten.",
+    "pump": "Pumpe",
+    "pumpDesc": "Brunnenpumpe oder Förderpumpe — startet automatisch mit der ersten Sektion und stoppt nach der letzten."
   },
   "sensors": {
     "title": "Sensoren",
@@ -194,11 +197,25 @@
       "rain": "Regen",
       "soil_wet": "Feuchter Boden",
       "frost": "Frost",
+      "flow_detected": "Unerwarteter Durchfluss",
       "manual_stop": "Manueller Stopp",
       "ha_unavailable": "HA nicht verfügbar"
     },
     "waterUsed": "Wasserverbrauch",
     "clearHistory": "Verlauf löschen",
     "clearConfirm": "Möchten Sie den Bewässerungsverlauf wirklich löschen?"
+  },
+  "settings": {
+    "title": "Einstellungen",
+    "language": "Sprache",
+    "colorTheme": "Farbschema",
+    "colorThemeDesc": "Passen Sie die 6 Hauptfarben der Oberfläche an. Geben Sie einen Hex-Wert (#rrggbb) ein oder verwenden Sie den Farbwähler.",
+    "colorPrimary": "Primär (Akzent, Schaltflächen)",
+    "colorPrimaryDark": "Primär dunkel (Hover)",
+    "colorBg": "Hintergrund",
+    "colorSurface": "Oberfläche (Karten)",
+    "colorBorder": "Rahmen",
+    "colorTextSecondary": "Sekundärer Text",
+    "resetColors": "Auf Standard zurücksetzen"
   }
 }

--- a/addon/frontend/public/locales/en/translation.json
+++ b/addon/frontend/public/locales/en/translation.json
@@ -56,6 +56,7 @@
     "manualStart": "Manual start",
     "quickStart": "Quick start",
     "wateringBlocked": "Watering blocked by sensors:",
+    "forceStart": "Force start (ignore sensor blocks)",
     "remaining": "remaining",
     "noZones": "No sections configured yet."
   },
@@ -89,7 +90,9 @@
     "turnOn": "Turn on",
     "turnOff": "Turn off",
     "mainValve": "Main valve",
-    "mainValveDesc": "Opens automatically before the first section starts and closes after the last section stops."
+    "mainValveDesc": "Opens automatically before the first section starts and closes after the last section stops.",
+    "pump": "Pump",
+    "pumpDesc": "Well pump or booster pump — starts automatically when first section starts and stops after the last stops."
   },
   "sensors": {
     "title": "Sensors",
@@ -194,11 +197,25 @@
       "rain": "Rain",
       "soil_wet": "Wet soil",
       "frost": "Frost",
+      "flow_detected": "Unexpected flow",
       "manual_stop": "Manual stop",
       "ha_unavailable": "HA unavailable"
     },
     "waterUsed": "Water used",
     "clearHistory": "Clear history",
     "clearConfirm": "Are you sure you want to clear watering history?"
+  },
+  "settings": {
+    "title": "Settings",
+    "language": "Language",
+    "colorTheme": "Color theme",
+    "colorThemeDesc": "Customize the 6 main colors of the interface. Enter a hex value (#rrggbb) or use the color picker.",
+    "colorPrimary": "Primary (accent, buttons)",
+    "colorPrimaryDark": "Primary dark (hover)",
+    "colorBg": "Background",
+    "colorSurface": "Surface (cards)",
+    "colorBorder": "Border",
+    "colorTextSecondary": "Secondary text",
+    "resetColors": "Reset to defaults"
   }
 }

--- a/addon/frontend/public/locales/pl/translation.json
+++ b/addon/frontend/public/locales/pl/translation.json
@@ -56,6 +56,7 @@
     "manualStart": "Ręczny start",
     "quickStart": "Szybki start",
     "wateringBlocked": "Podlewanie zablokowane przez czujniki:",
+    "forceStart": "Wymuś start (ignoruj blokady czujników)",
     "remaining": "pozostało",
     "noZones": "Brak skonfigurowanych sekcji."
   },
@@ -89,7 +90,9 @@
     "turnOn": "Włącz",
     "turnOff": "Wyłącz",
     "mainValve": "Zawór główny",
-    "mainValveDesc": "Otwiera się automatycznie przed uruchomieniem pierwszej sekcji i zamyka po zatrzymaniu ostatniej."
+    "mainValveDesc": "Otwiera się automatycznie przed uruchomieniem pierwszej sekcji i zamyka po zatrzymaniu ostatniej.",
+    "pump": "Pompa",
+    "pumpDesc": "Pompa ze studni lub pompa wspomagająca — uruchamia się automatycznie przed pierwszą sekcją i zatrzymuje po ostatniej."
   },
   "sensors": {
     "title": "Czujniki",
@@ -194,11 +197,25 @@
       "rain": "Deszcz",
       "soil_wet": "Mokra gleba",
       "frost": "Mróz",
+      "flow_detected": "Nieoczekiwany przepływ",
       "manual_stop": "Ręczne zatrzymanie",
       "ha_unavailable": "HA niedostępne"
     },
     "waterUsed": "Zużycie wody",
     "clearHistory": "Wyczyść historię",
     "clearConfirm": "Czy na pewno chcesz wyczyścić historię podlewania?"
+  },
+  "settings": {
+    "title": "Ustawienia",
+    "language": "Język",
+    "colorTheme": "Motyw kolorystyczny",
+    "colorThemeDesc": "Dostosuj 6 głównych kolorów interfejsu. Wpisz wartość hex (#rrggbb) lub użyj próbnika kolorów.",
+    "colorPrimary": "Główny (akcent, przyciski)",
+    "colorPrimaryDark": "Główny ciemny (hover)",
+    "colorBg": "Tło",
+    "colorSurface": "Powierzchnia (karty)",
+    "colorBorder": "Obramowanie",
+    "colorTextSecondary": "Tekst drugorzędny",
+    "resetColors": "Przywróć domyślne"
   }
 }

--- a/addon/frontend/src/App.tsx
+++ b/addon/frontend/src/App.tsx
@@ -8,6 +8,7 @@ import SensorsPage from './pages/SensorsPage'
 import SchedulePage from './pages/SchedulePage'
 import WeatherPage from './pages/WeatherPage'
 import HistoryPage from './pages/HistoryPage'
+import SettingsPage from './pages/SettingsPage'
 import { useWebSocket } from './hooks/useWebSocket'
 
 function App() {
@@ -25,6 +26,7 @@ function App() {
           <Route path="/schedule" element={<SchedulePage />} />
           <Route path="/weather" element={<WeatherPage />} />
           <Route path="/history" element={<HistoryPage />} />
+          <Route path="/settings" element={<SettingsPage />} />
           <Route path="*" element={<Navigate to="/dashboard" replace />} />
         </Routes>
       </AppLayout>

--- a/addon/frontend/src/api/irrigation.ts
+++ b/addon/frontend/src/api/irrigation.ts
@@ -3,8 +3,8 @@ import type { IrrigationStatus } from '../types'
 
 export const irrigationApi = {
   status: () => client.get<IrrigationStatus>('/api/irrigation/status').then(r => r.data),
-  start: (zoneId: number, durationMin?: number) =>
-    client.post(`/api/irrigation/start/${zoneId}`, { duration_min: durationMin }).then(r => r.data),
+  start: (zoneId: number, durationMin?: number, force?: boolean) =>
+    client.post(`/api/irrigation/start/${zoneId}`, { duration_min: durationMin, force: force ?? false }).then(r => r.data),
   stop: (zoneId: number) =>
     client.post(`/api/irrigation/stop/${zoneId}`).then(r => r.data),
   stopAll: () => client.post('/api/irrigation/stop-all').then(r => r.data),

--- a/addon/frontend/src/components/Layout/AppLayout.tsx
+++ b/addon/frontend/src/components/Layout/AppLayout.tsx
@@ -2,13 +2,18 @@ import { useEffect, type ReactNode } from 'react'
 import { useTranslation } from 'react-i18next'
 import Sidebar from './Sidebar'
 import HeaderBar from './HeaderBar'
-import { useIrrigationStore } from '../../store/irrigationStore'
+import { useIrrigationStore, applyThemeColors, DEFAULT_COLORS, type ThemeColors } from '../../store/irrigationStore'
 import { INGRESS_BASE } from '../../lib/ingressBase'
+import { settingsApi } from '../../api/settings'
+
+const COLOR_KEYS: (keyof ThemeColors)[] = ['primary', 'primaryDark', 'bg', 'surface', 'border', 'textSecondary']
+const SETTING_KEYS = ['theme_color_primary', 'theme_color_primary_dark', 'theme_color_bg', 'theme_color_surface', 'theme_color_border', 'theme_color_text_secondary']
 
 export default function AppLayout({ children }: { children: ReactNode }) {
   const theme = useIrrigationStore(s => s.theme)
   const sidebarOpen = useIrrigationStore(s => s.sidebarOpen)
   const closeSidebar = useIrrigationStore(s => s.closeSidebar)
+  const setThemeColors = useIrrigationStore(s => s.setThemeColors)
   const { i18n } = useTranslation()
 
   useEffect(() => {
@@ -16,16 +21,28 @@ export default function AppLayout({ children }: { children: ReactNode }) {
   }, [theme])
 
   useEffect(() => {
-    localStorage.removeItem('irrigation-lang-override')
     fetch(`${INGRESS_BASE}/api/config`)
       .then(r => r.json())
       .then(cfg => {
-        if (cfg.language) {
-          i18n.changeLanguage(cfg.language)
-        }
+        if (cfg.language) i18n.changeLanguage(cfg.language)
       })
       .catch(() => {})
   }, [i18n])
+
+  useEffect(() => {
+    settingsApi.getAll().then(cfg => {
+      const colors: Partial<ThemeColors> = {}
+      COLOR_KEYS.forEach((key, i) => {
+        const val = cfg[SETTING_KEYS[i]]
+        if (val) colors[key] = val
+      })
+      if (Object.keys(colors).length > 0) {
+        setThemeColors(colors)
+      } else {
+        applyThemeColors(DEFAULT_COLORS)
+      }
+    }).catch(() => { applyThemeColors(DEFAULT_COLORS) })
+  }, [setThemeColors])
 
   return (
     <div className="flex h-screen overflow-hidden bg-gray-100 dark:bg-gray-950">

--- a/addon/frontend/src/components/Layout/Sidebar.tsx
+++ b/addon/frontend/src/components/Layout/Sidebar.tsx
@@ -2,7 +2,7 @@ import { NavLink } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import {
   LayoutDashboard, Layers, Zap, Radio, CalendarDays,
-  Cloud, History, Sun, Moon, X,
+  Cloud, History, Sun, Moon, X, Settings,
 } from 'lucide-react'
 import clsx from 'clsx'
 import { useIrrigationStore } from '../../store/irrigationStore'
@@ -15,6 +15,7 @@ const navItems = [
   { to: '/schedule',  icon: CalendarDays,    label: 'nav.schedule' },
   { to: '/weather',   icon: Cloud,           label: 'nav.weather' },
   { to: '/history',   icon: History,         label: 'nav.history' },
+  { to: '/settings',  icon: Settings,        label: 'nav.settings' },
 ]
 
 export default function Sidebar() {

--- a/addon/frontend/src/index.css
+++ b/addon/frontend/src/index.css
@@ -2,6 +2,15 @@
 @tailwind components;
 @tailwind utilities;
 
+:root {
+  --theme-primary: #22c55e;
+  --theme-primary-dark: #16a34a;
+  --theme-bg: #030712;
+  --theme-surface: #111827;
+  --theme-border: #1f2937;
+  --theme-text-secondary: #9ca3af;
+}
+
 @layer base {
   body {
     @apply bg-gray-100 dark:bg-gray-950 text-gray-900 dark:text-gray-100 font-sans;
@@ -15,6 +24,26 @@
   ::-webkit-scrollbar-thumb {
     @apply bg-gray-400 dark:bg-gray-700 rounded-full;
   }
+}
+
+/* Theme color overrides — applied when CSS vars are set via Settings */
+.dark .btn-primary {
+  background-color: var(--theme-primary-dark);
+}
+.dark .btn-primary:hover {
+  background-color: var(--theme-primary);
+}
+.dark body {
+  background-color: var(--theme-bg);
+}
+.dark .card,
+.dark [class*="bg-gray-900"] {
+  background-color: var(--theme-surface);
+  border-color: var(--theme-border);
+}
+.dark [class*="border-gray-800"],
+.dark [class*="border-gray-700"] {
+  border-color: var(--theme-border);
 }
 
 @layer components {

--- a/addon/frontend/src/pages/DashboardPage.tsx
+++ b/addon/frontend/src/pages/DashboardPage.tsx
@@ -39,6 +39,7 @@ export default function DashboardPage() {
   const [quickDuration, setQuickDuration] = useState<number>(15)
   const [startModalZone, setStartModalZone] = useState<Zone | null>(null)
   const [startModalDuration, setStartModalDuration] = useState<number>(15)
+  const [startModalForce, setStartModalForce] = useState<boolean>(false)
 
   useEffect(() => {
     zonesApi.list().then(setZones).catch(() => {})
@@ -72,14 +73,14 @@ export default function DashboardPage() {
     return formatNextRun(sorted[0].next_run)
   }
 
-  const startZoneWithDuration = async (zoneId: number, durationMin: number, closeModal = false) => {
+  const startZoneWithDuration = async (zoneId: number, durationMin: number, closeModal = false, force = false) => {
     setStartingZone(zoneId)
     try {
-      await irrigationApi.start(zoneId, durationMin)
+      await irrigationApi.start(zoneId, durationMin, force)
     } catch {}
     finally {
       setStartingZone(null)
-      if (closeModal) setStartModalZone(null)
+      if (closeModal) { setStartModalZone(null); setStartModalForce(false) }
     }
   }
 
@@ -91,11 +92,12 @@ export default function DashboardPage() {
   const openStartModal = (zone: Zone) => {
     setStartModalZone(zone)
     setStartModalDuration(zone.duration_min)
+    setStartModalForce(false)
   }
 
   const handleStartFromModal = async () => {
     if (!startModalZone) return
-    await startZoneWithDuration(startModalZone.id, startModalDuration, true)
+    await startZoneWithDuration(startModalZone.id, startModalDuration, true, startModalForce)
   }
 
   const handleStop = async (zoneId: number) => {
@@ -304,6 +306,16 @@ export default function DashboardPage() {
               onChange={(e) => setStartModalDuration(Number(e.target.value))}
             />
           </div>
+          {blockingSensors.length > 0 && (
+            <div className="bg-yellow-900/20 border border-yellow-800 rounded-lg px-3 py-2">
+              <p className="text-yellow-400 text-xs mb-2">⚠️ {t('dashboard.wateringBlocked')}</p>
+              <div className="flex items-center gap-2">
+                <input type="checkbox" id="modal-force" checked={startModalForce}
+                  onChange={e => setStartModalForce(e.target.checked)} className="w-4 h-4 accent-primary-500" />
+                <label htmlFor="modal-force" className="text-sm text-gray-300">{t('dashboard.forceStart')}</label>
+              </div>
+            </div>
+          )}
           <div className="flex gap-3 justify-end border-t border-gray-200 dark:border-gray-800 pt-3">
             <button onClick={() => setStartModalZone(null)} className="btn-secondary btn-sm">{t('common.cancel')}</button>
             <button

--- a/addon/frontend/src/pages/SettingsPage.tsx
+++ b/addon/frontend/src/pages/SettingsPage.tsx
@@ -1,0 +1,198 @@
+import { useState, useEffect } from 'react'
+import { useTranslation } from 'react-i18next'
+import { Settings, Palette, Globe, RotateCcw } from 'lucide-react'
+import { settingsApi } from '../api/settings'
+import { useIrrigationStore, DEFAULT_COLORS, type ThemeColors } from '../store/irrigationStore'
+
+type LangCode = 'en' | 'pl' | 'de'
+
+const LANGUAGES: { code: LangCode; label: string }[] = [
+  { code: 'en', label: 'English' },
+  { code: 'pl', label: 'Polski' },
+  { code: 'de', label: 'Deutsch' },
+]
+
+interface ColorField {
+  key: keyof ThemeColors
+  settingKey: string
+  labelKey: string
+}
+
+const COLOR_FIELDS: ColorField[] = [
+  { key: 'primary',       settingKey: 'theme_color_primary',            labelKey: 'settings.colorPrimary' },
+  { key: 'primaryDark',   settingKey: 'theme_color_primary_dark',       labelKey: 'settings.colorPrimaryDark' },
+  { key: 'bg',            settingKey: 'theme_color_bg',                 labelKey: 'settings.colorBg' },
+  { key: 'surface',       settingKey: 'theme_color_surface',            labelKey: 'settings.colorSurface' },
+  { key: 'border',        settingKey: 'theme_color_border',             labelKey: 'settings.colorBorder' },
+  { key: 'textSecondary', settingKey: 'theme_color_text_secondary',     labelKey: 'settings.colorTextSecondary' },
+]
+
+function isValidHex(v: string): boolean {
+  return /^#([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/.test(v)
+}
+
+export default function SettingsPage() {
+  const { t, i18n } = useTranslation()
+  const { themeColors, setThemeColors } = useIrrigationStore()
+  const [lang, setLang] = useState<LangCode>('en')
+  const [colors, setColors] = useState<ThemeColors>({ ...DEFAULT_COLORS })
+  const [hexInputs, setHexInputs] = useState<Record<string, string>>({})
+  const [savedMsg, setSavedMsg] = useState('')
+
+  useEffect(() => {
+    settingsApi.getAll().then(cfg => {
+      if (cfg['app_language']) setLang(cfg['app_language'] as LangCode)
+      const loaded: Partial<ThemeColors> = {}
+      COLOR_FIELDS.forEach(f => {
+        const val = cfg[f.settingKey]
+        if (val) loaded[f.key] = val
+      })
+      const merged = { ...DEFAULT_COLORS, ...loaded }
+      setColors(merged)
+      const inputs: Record<string, string> = {}
+      COLOR_FIELDS.forEach(f => { inputs[f.key] = merged[f.key] })
+      setHexInputs(inputs)
+    }).catch(() => {})
+  }, [])
+
+  // sync from store when changed externally
+  useEffect(() => {
+    setColors({ ...themeColors })
+    const inputs: Record<string, string> = {}
+    COLOR_FIELDS.forEach(f => { inputs[f.key] = themeColors[f.key] })
+    setHexInputs(inputs)
+  }, [themeColors])
+
+  const saveLang = async (code: LangCode) => {
+    setLang(code)
+    i18n.changeLanguage(code)
+    await settingsApi.set('app_language', code)
+    showSaved()
+  }
+
+  const updateColor = (field: ColorField, value: string) => {
+    setHexInputs(prev => ({ ...prev, [field.key]: value }))
+    if (isValidHex(value)) {
+      const next = { ...colors, [field.key]: value }
+      setColors(next)
+      setThemeColors({ [field.key]: value })
+    }
+  }
+
+  const saveColors = async () => {
+    await Promise.all(
+      COLOR_FIELDS.map(f => settingsApi.set(f.settingKey, colors[f.key]))
+    )
+    showSaved()
+  }
+
+  const resetColors = async () => {
+    setColors({ ...DEFAULT_COLORS })
+    const inputs: Record<string, string> = {}
+    COLOR_FIELDS.forEach(f => { inputs[f.key] = DEFAULT_COLORS[f.key] })
+    setHexInputs(inputs)
+    setThemeColors({ ...DEFAULT_COLORS })
+    await Promise.all(
+      COLOR_FIELDS.map(f => settingsApi.set(f.settingKey, DEFAULT_COLORS[f.key]))
+    )
+    showSaved()
+  }
+
+  const showSaved = () => {
+    setSavedMsg(t('common.success'))
+    setTimeout(() => setSavedMsg(''), 2000)
+  }
+
+  return (
+    <div className="space-y-6 max-w-2xl">
+      <h1 className="text-xl font-bold text-gray-900 dark:text-white flex items-center gap-2">
+        <Settings size={20} />
+        {t('settings.title')}
+      </h1>
+
+      {savedMsg && (
+        <div className="bg-primary-900/40 border border-primary-700 text-primary-300 text-sm rounded-lg px-4 py-2">
+          ✓ {savedMsg}
+        </div>
+      )}
+
+      {/* Language */}
+      <div className="card space-y-3">
+        <div className="flex items-center gap-2 mb-1">
+          <Globe size={15} className="text-primary-400" />
+          <span className="text-sm font-semibold text-gray-900 dark:text-white">{t('settings.language')}</span>
+        </div>
+        <div className="flex gap-2 flex-wrap">
+          {LANGUAGES.map(l => (
+            <button
+              key={l.code}
+              onClick={() => saveLang(l.code)}
+              className={`px-4 py-2 rounded-lg text-sm font-medium transition-colors ${
+                lang === l.code
+                  ? 'bg-primary-700 text-white'
+                  : 'bg-gray-200 dark:bg-gray-800 text-gray-700 dark:text-gray-300 hover:bg-gray-300 dark:hover:bg-gray-700'
+              }`}
+            >
+              {l.label}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* Color theme */}
+      <div className="card space-y-4">
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-2">
+            <Palette size={15} className="text-primary-400" />
+            <span className="text-sm font-semibold text-gray-900 dark:text-white">{t('settings.colorTheme')}</span>
+          </div>
+          <button
+            onClick={resetColors}
+            className="flex items-center gap-1.5 text-xs text-gray-500 hover:text-gray-300 transition-colors"
+          >
+            <RotateCcw size={12} />
+            {t('settings.resetColors')}
+          </button>
+        </div>
+
+        <p className="text-xs text-gray-500">{t('settings.colorThemeDesc')}</p>
+
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+          {COLOR_FIELDS.map(field => (
+            <div key={field.key} className="space-y-1">
+              <label className="label">{t(field.labelKey)}</label>
+              <div className="flex gap-2 items-center">
+                <input
+                  type="color"
+                  value={isValidHex(hexInputs[field.key] ?? colors[field.key]) ? (hexInputs[field.key] ?? colors[field.key]) : '#000000'}
+                  onChange={e => updateColor(field, e.target.value)}
+                  className="w-10 h-9 rounded cursor-pointer border border-gray-600 bg-transparent p-0.5"
+                />
+                <input
+                  type="text"
+                  value={hexInputs[field.key] ?? colors[field.key]}
+                  onChange={e => updateColor(field, e.target.value)}
+                  placeholder="#rrggbb"
+                  maxLength={7}
+                  className={`input text-sm font-mono ${
+                    isValidHex(hexInputs[field.key] ?? '') ? '' : 'border-red-600'
+                  }`}
+                />
+                <div
+                  className="w-9 h-9 rounded-lg shrink-0 border border-gray-600"
+                  style={{ backgroundColor: isValidHex(colors[field.key]) ? colors[field.key] : '#888' }}
+                />
+              </div>
+            </div>
+          ))}
+        </div>
+
+        <div className="flex justify-end pt-2 border-t border-gray-200 dark:border-gray-800">
+          <button onClick={saveColors} className="btn-primary btn-sm">
+            {t('common.save')}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/addon/frontend/src/pages/ValvesPage.tsx
+++ b/addon/frontend/src/pages/ValvesPage.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
-import { Plus, Pencil, Trash2, Zap, ToggleLeft, ToggleRight, ShieldCheck } from 'lucide-react'
+import { Plus, Pencil, Trash2, Zap, ToggleLeft, ToggleRight, ShieldCheck, Waves } from 'lucide-react'
 import { valvesApi } from '../api/valves'
 import { haEntitiesApi } from '../api/weather'
 import { settingsApi } from '../api/settings'
@@ -167,6 +167,58 @@ function MainValveSection({ t }: { t: (k: string) => string }) {
   )
 }
 
+function PumpSection({ t }: { t: (k: string) => string }) {
+  const [entity, setEntity] = useState('')
+  const [saved, setSaved] = useState(false)
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState('')
+
+  useEffect(() => {
+    settingsApi.getAll().then(cfg => {
+      setEntity(typeof cfg['pump_entity_id'] === 'string' ? cfg['pump_entity_id'] : '')
+    }).catch(() => {})
+  }, [])
+
+  const save = async () => {
+    setSaving(true)
+    setError('')
+    setSaved(false)
+    try {
+      const result = await settingsApi.set('pump_entity_id', entity || null)
+      setEntity(typeof result?.value === 'string' ? result.value : '')
+      setSaved(true)
+      setTimeout(() => setSaved(false), 2000)
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : String(e))
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <div className="card border-blue-700/40 max-w-4xl">
+      <div className="flex flex-col lg:flex-row lg:items-center gap-3">
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-2 mb-1">
+            <Waves size={16} className="text-blue-400" />
+            <span className="text-sm font-semibold text-gray-900 dark:text-white">{t('valves.pump')}</span>
+          </div>
+          <p className="text-xs text-gray-500 dark:text-gray-400">{t('valves.pumpDesc')}</p>
+        </div>
+        <div className="flex gap-2 w-full lg:w-[460px]">
+          <div className="flex-1">
+            <EntityPicker value={entity} onChange={setEntity} type="valves" />
+          </div>
+          <button onClick={save} disabled={saving} className="btn-primary btn-sm shrink-0 min-w-[88px] disabled:opacity-60">
+            {saved ? 'OK' : t('common.save')}
+          </button>
+        </div>
+      </div>
+      {error && <p className="mt-2 text-xs text-red-500">{error}</p>}
+    </div>
+  )
+}
+
 export default function ValvesPage() {
   const { t } = useTranslation()
   const [valves, setValves] = useState<Valve[]>([])
@@ -221,6 +273,7 @@ export default function ValvesPage() {
       </div>
 
       <MainValveSection t={t} />
+      <PumpSection t={t} />
       {loading ? <p className="text-gray-500 text-sm">{t('common.loading')}</p>
       : valves.length === 0 ? (
         <div className="card text-center py-14 text-gray-600">

--- a/addon/frontend/src/store/irrigationStore.ts
+++ b/addon/frontend/src/store/irrigationStore.ts
@@ -3,6 +3,34 @@ import type { ActiveZone, Sensor } from '../types'
 
 type Theme = 'dark' | 'light'
 
+export interface ThemeColors {
+  primary: string
+  primaryDark: string
+  bg: string
+  surface: string
+  border: string
+  textSecondary: string
+}
+
+export const DEFAULT_COLORS: ThemeColors = {
+  primary: '#22c55e',
+  primaryDark: '#16a34a',
+  bg: '#030712',
+  surface: '#111827',
+  border: '#1f2937',
+  textSecondary: '#9ca3af',
+}
+
+export function applyThemeColors(colors: Partial<ThemeColors>) {
+  const root = document.documentElement
+  if (colors.primary) root.style.setProperty('--theme-primary', colors.primary)
+  if (colors.primaryDark) root.style.setProperty('--theme-primary-dark', colors.primaryDark)
+  if (colors.bg) root.style.setProperty('--theme-bg', colors.bg)
+  if (colors.surface) root.style.setProperty('--theme-surface', colors.surface)
+  if (colors.border) root.style.setProperty('--theme-border', colors.border)
+  if (colors.textSecondary) root.style.setProperty('--theme-text-secondary', colors.textSecondary)
+}
+
 interface IrrigationStore {
   activeZones: ActiveZone[]
   anyWatering: boolean
@@ -10,12 +38,14 @@ interface IrrigationStore {
   wsConnected: boolean
   theme: Theme
   sidebarOpen: boolean
+  themeColors: ThemeColors
   setActiveZones: (zones: ActiveZone[]) => void
   setBlockingSensors: (sensors: Sensor[]) => void
   setWsConnected: (v: boolean) => void
   toggleTheme: () => void
   toggleSidebar: () => void
   closeSidebar: () => void
+  setThemeColors: (colors: Partial<ThemeColors>) => void
 }
 
 const savedTheme = (localStorage.getItem('irrigation-theme') as Theme) || 'dark'
@@ -27,6 +57,7 @@ export const useIrrigationStore = create<IrrigationStore>((set, get) => ({
   wsConnected: false,
   theme: savedTheme,
   sidebarOpen: false,
+  themeColors: { ...DEFAULT_COLORS },
   setActiveZones: (zones) => set({ activeZones: zones, anyWatering: zones.length > 0 }),
   setBlockingSensors: (sensors) => set({ blockingSensors: sensors }),
   setWsConnected: (v) => set({ wsConnected: v }),
@@ -37,4 +68,9 @@ export const useIrrigationStore = create<IrrigationStore>((set, get) => ({
   },
   toggleSidebar: () => set(s => ({ sidebarOpen: !s.sidebarOpen })),
   closeSidebar: () => set({ sidebarOpen: false }),
+  setThemeColors: (colors) => {
+    const merged = { ...get().themeColors, ...colors }
+    applyThemeColors(merged)
+    set({ themeColors: merged })
+  },
 }))


### PR DESCRIPTION
## Changes in v1.4.3

### Bug fixes
- **Flow sensor history**: flow meter sensor now correctly reports Unexpected flow instead of Wet soil in irrigation history (issue #36)
- **Safety valve sweep**: all zone valves are explicitly closed when the last active zone finishes — prevents stuck-open valves
- **Force start**: manual zone start now has a *Force start* checkbox to bypass active sensor blocks (soil, rain, frost, flow)

### New features
- **Pump control**: configure a pump entity (e.g. well pump) in the Valves page — it starts automatically when the first section starts and stops after the last section stops, mirroring main valve behaviour
- **Settings page**: new /settings route with language selector (EN/PL/DE) and 6 customisable interface colours (hex input + colour picker), all persisted to the database